### PR TITLE
build: get stared with aspect_rules_js

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+common --enable_bzlmod

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
           path: "~/.cache/bazel"
           key: bazel
       - name: Build 
-        run: bazel --version
+        run: bazel build ...

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,1 @@
+bazel_dep(name = "aspect_rules_js", version = "1.15.1")

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@aspect_rules_js//js:defs.bzl", "js_binary")
+
+js_binary(
+    name = "bin",
+    entry_point = "index.js",
+)

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,1 @@
+console.log("Hello World");


### PR DESCRIPTION
- build(bazel): enable bzlmod by default
- build(bazel): add empty BUILD file to get started
- build(bazel): add aspect_rules_js as module dependency
- add dummy JS file to test rules_js
- build(ci): run 'bazel build ...' in CI
