### PR TITLE
Support npm dependencies via pnpm and rules_js

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,3 @@
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages()

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,3 +2,10 @@ bazel_dep(name = "aspect_rules_js", version = "1.15.1")
 
 pnpm = use_extension("@aspect_rules_js//npm:extensions.bzl", "pnpm")
 use_repo(pnpm, "pnpm")
+
+npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependency = True)
+npm.npm_translate_lock(
+    name = "npm",
+    pnpm_lock = "//:pnpm-lock.yaml",
+)
+use_repo(npm, "npm")

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # Generator for papercraft dungeon tiles
+
+## Development Guide
+
+- after changing any `package.json`, run `bazel run @pnpm//:pnpm -- install --dir "$PWD" --lockfile-only` in the repo root to update the `pnpm-lock.yaml`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,16 @@
+lockfileVersion: 5.4
+
+importers:
+
+  src:
+    specifiers:
+      chalk: ^5.2.0
+    dependencies:
+      chalk: 5.2.0
+
+packages:
+
+  /chalk/5.2.0:
+    resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
+    engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+    dev: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'src'

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,6 +1,12 @@
 load("@aspect_rules_js//js:defs.bzl", "js_binary")
+load("@npm//:defs.bzl", "npm_link_all_packages")
+
+npm_link_all_packages()
 
 js_binary(
     name = "bin",
-    entry_point = "index.js",
+    entry_point = "index.mjs",
+    data = [
+        ":node_modules/chalk",
+    ]
 )

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,0 @@
-console.log("Hello World");

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,3 @@
+import chalk from "chalk" 
+
+console.log(chalk.red("Hello") + " " + chalk.green("World"));

--- a/src/package.json
+++ b/src/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "chalk":"^5.2.0"
+    }
+}


### PR DESCRIPTION
Set up dependency management with pnpm and rules_js.
Add chalk dependency as example.