### PR TITLE
Improve node_modules documentation and setup

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,1 @@
+src/node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/node_modules
+
 /bazel-bin
 /bazel-out
 /bazel-papercraft-dungeon-generator

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -7,6 +7,7 @@ npm = use_extension("@aspect_rules_js//npm:extensions.bzl", "npm", dev_dependenc
 npm.npm_translate_lock(
     name = "npm",
     pnpm_lock = "//:pnpm-lock.yaml",
+    verify_node_modules_ignored = "//:.bazelignore"
 )
 use_repo(npm, "npm")
 

--- a/README.md
+++ b/README.md
@@ -2,4 +2,15 @@
 
 ## Development Guide
 
-- after changing any `package.json`, run `bazel run @pnpm//:pnpm -- install --dir "$PWD" --lockfile-only` in the repo root to update the `pnpm-lock.yaml`
+NPM dependencies are declared with version ranges in `package.json` and then repeated without version ranges in `BUILD.bazel`. To reflect changes in `package.json` or to set up your editor or other local tooling, run
+
+```
+bazel run @pnpm//:pnpm -- install --dir "$PWD"
+```
+
+in the repository root. It will do the following things:
+
+- resolve version ranges and transitive dependencies, reading and if necessary writing `pnpm-lock.yaml`
+- install dependencies into `node_modules` folders in the source tree, to be used by your editor and other local tooling
+
+Bazel will pick up the dependencies from `pnpm-lock.yaml` and install them again for `bazel build`, `bazel test`, and `bazel run` commands.


### PR DESCRIPTION
As discussed on Discord, the setup feels unwieldy. This PR doesn't change the setup itself, but at least documents things a bit better and adds a safety net in the form of `verify_node_modules_ignored`.